### PR TITLE
Introduce opportunistic automatic horizontal scroll

### DIFF
--- a/konata_renderer.js
+++ b/konata_renderer.js
@@ -652,7 +652,7 @@ class KonataRenderer{
         // 背景をクリア
         let ctx = tile.getContext("2d");
         ctx.fillStyle = self.style_.labelPane.backgroundColor;//"rgb(245,245,245)";
-        ctx.fillRect(0, 0, tile.width, tile.height);
+        ctx.fillRect(0, 0, tile.clientWidth, tile.clientHeight);
 
         // 小さくなりすぎたらスキップ
         if (!self.canDrawText) {
@@ -665,8 +665,8 @@ class KonataRenderer{
         ctx.fillStyle = self.style_.labelPane.fontColor;
 
         // スケールを勘案した論理サイズに変換
-        let logHeight = tile.height / self.opH_;
-        //let logWidth = tile.width / (scale * self.opW_);
+        let logHeight = tile.clientHeight / self.opH_;
+        //let logWidth = tile.clientWidth / (scale * self.opW_);
         
         let marginLeft = self.style_.labelPane.marginLeft;
         let marginTop = (self.laneH_ - self.lane_height_margin_*2 - fontSizeRaw) / 2 + fontSizeRaw;
@@ -703,21 +703,21 @@ class KonataRenderer{
     drawPipelineTile_(tile, top, left){
         let self = this;
         let scale = self.zoomScale_;
-        let height = tile.height / self.opH_;
-        let width = tile.width / self.opW_;
+        let height = tile.clientHeight / self.opH_;
+        let width = tile.clientWidth / self.opW_;
 
         let ctx = tile.getContext("2d");
         ctx.fillStyle = self.style_.pipelinePane.backgroundColor; //"rgb(255,255,255)";
-        ctx.fillRect(0, 0, tile.width, tile.height);
+        ctx.fillRect(0, 0, tile.clientWidth, tile.clientHeight);
 
         // 上側にはみ出ていた場合，暗く描画
         let offsetY = 0;
         if (top < 0) {
             let bottom = -top * self.opH_ + self.PIXEL_ADJUST;
-            bottom = Math.min(tile.height, bottom);
+            bottom = Math.min(tile.clientHeight, bottom);
             ctx.fillStyle = this.style_.pipelinePane.invalidBackgroundColor;
-            ctx.fillRect(0, 0, tile.width, bottom);
-            if (bottom >= tile.height) {
+            ctx.fillRect(0, 0, tile.clientWidth, bottom);
+            if (bottom >= tile.clientHeight) {
                 return;
             }
             offsetY = -top;
@@ -771,10 +771,10 @@ class KonataRenderer{
         // 下側にはみ出ていた場合，暗く描画
         let bottomOuterHeight = top - offsetY + height - 1 - self.getVisibleBottom();
         if (bottomOuterHeight > 0) {
-            let begin = tile.height - bottomOuterHeight * self.opH_ + self.PIXEL_ADJUST;
+            let begin = tile.clientHeight - bottomOuterHeight * self.opH_ + self.PIXEL_ADJUST;
             begin = Math.max(0, begin);
             ctx.fillStyle = this.style_.pipelinePane.invalidBackgroundColor;
-            ctx.fillRect(0, begin, tile.width, tile.height);
+            ctx.fillRect(0, begin, tile.clientWidth, tile.clientHeight);
         }
     }
 

--- a/konata_renderer.js
+++ b/konata_renderer.js
@@ -265,18 +265,21 @@ class KonataRenderer{
     computeDiffXMinimizingMargin(left, top, width, height)
     {
         const right = left + width;
-        const bottom = top + height - 1;
-        const topOpPos = Math.max(Math.floor(top), 0);
-        const topOp = this.getVisibleOp(topOpPos, this.opResolution);
-        const bottomOpPos = Math.min(Math.floor(bottom), this.getVisibleBottom());
-        const bottomOp = this.getVisibleOp(bottomOpPos, this.opResolution);
+        let min = Infinity;
+        let max = -Infinity;
 
-        if (!topOp || !bottomOp) {
-            return 0;
+        for (let y = Math.floor(top); y < top + height; y++) {
+            const op = this.getVisibleOp(y, this.opResolution);
+            if (!op) {
+                continue;
+            }
+
+            min = Math.min(min, op.fetchedCycle);
+            max = Math.max(max, op.retiredCycle);
         }
 
-        const leftOffset = topOp.fetchedCycle - left;
-        const rightOffset = bottomOp.retiredCycle - right;
+        const leftOffset = min - left;
+        const rightOffset = max - right;
 
         // Constrain the direction; scroll only if both leftOffset and
         // rightOffset have the same direction.
@@ -787,9 +790,7 @@ class KonataRenderer{
                 continue;   
             }
 
-            if (!self.drawOp_(op, y - top + offsetY, left, left + self.viewWidth_, scale, ctx)) {
-                skipRendering = true;
-            }
+            self.drawOp_(op, y - top + offsetY, left, left + self.viewWidth_, scale, ctx);
         }
 
         // 依存関係
@@ -976,13 +977,10 @@ class KonataRenderer{
         let self = this;
         let top = h * self.opH_ + self.PIXEL_ADJUST;
         
-        if (op.retiredCycle < startCycle) {
-            return true;
-        } else if (endCycle < op.fetchedCycle) {
-            return false;
-        }
-        if (op.retiredCycle == op.fetchedCycle) {
-            return true;
+        if (op.retiredCycle < startCycle ||
+            endCycle < op.fetchedCycle ||
+            op.retiredCycle == op.fetchedCycle) {
+            return;
         }
         let l = startCycle > op.fetchedCycle ? (startCycle - 1) : op.fetchedCycle; l -= startCycle;
         let r = endCycle >= op.retiredCycle ? op.retiredCycle : (endCycle + 1); r -= startCycle;
@@ -1050,7 +1048,6 @@ class KonataRenderer{
             }
 
         }
-        return true;
     }
 
     drawLane_(op, h, startCycle, endCycle, scale, ctx, laneName){


### PR DESCRIPTION
```
tl; dr: The old algorithm made a large amount of automatic horizontal
scroll in some scenarios and hurt usability. Introduce a new
"opportunistic" algorithm that horizontally scrolls to the extent that
will show more of pipeline stages.

Konata automatically scrolls horizontally when the user inputs a
vertical scroll. Previously, the amount of automatic horizontal scroll
was determined by the difference between the fetch timing of the op at
the top before the vertical scroll and one of the op at the top after
the vertical scroll.

The old algorithm resulted in an excessive scroll when the fetch
timing difference is large. For example, think of a scenario that
an op immediately after a branch misprediction is at the top. You
naturally scroll upward to see what happened just before the op, but
since the mispredicted branch was fetched much earlier, the old
algorithm decides to travel to the past too distant, and you miss the
pipeline stages you intended to observe. There will be completely
unobservable regions in the worst scenario where branch mispredictions
frequently happen.

By contrast, the new algorithm behaves opportunistically; it
horizontally scrolls only if there is some margin and scrolling will
show more of pipeline stages, hence immune to excessive scroll in the
scenario described earlier.

The new algorithm also preserves a margin present before the vertical
scroll because a user may want to display somewhere away from the
currently active pipeline because the user is interested in another
pipeline shown in the transparent mode.
```